### PR TITLE
added double quotes for input name

### DIFF
--- a/src/Editor.php
+++ b/src/Editor.php
@@ -32,7 +32,7 @@ $('#{$this->id}').summernote($config);
 
 $('#{$this->id}').on("summernote.change", function (e) {
     var html = $('#{$this->id}').summernote('code');
-    $('input[name=$name]').val(html);
+    $('input[name="{$name}"]').val(html);
 });
 
 EOT;


### PR DESCRIPTION
Error when using summernote with relation fields: 

>  "Syntax error, unrecognized expression: input[name=salesforcesync[newsletter_texts]]"

Fix this error in js script on change event  by adding double quotes around name in input name selector. 